### PR TITLE
Added Square/Cube shape next to Point and Line. Added rendering for exclusively this frame.

### DIFF
--- a/Draw3D.gd
+++ b/Draw3D.gd
@@ -4,7 +4,7 @@ func line(pos1: Vector3, pos2: Vector3, color = Color.WHITE_SMOKE, persist_ms = 
 	var mesh_instance := MeshInstance3D.new()
 	var immediate_mesh := ImmediateMesh.new()
 	var material := ORMMaterial3D.new()
-	
+
 	mesh_instance.mesh = immediate_mesh
 	mesh_instance.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
 
@@ -12,38 +12,57 @@ func line(pos1: Vector3, pos2: Vector3, color = Color.WHITE_SMOKE, persist_ms = 
 	immediate_mesh.surface_add_vertex(pos1)
 	immediate_mesh.surface_add_vertex(pos2)
 	immediate_mesh.surface_end()
-	
+
 	material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
 	material.albedo_color = color
-	
-	get_tree().get_root().add_child(mesh_instance)
-	if persist_ms:
-		await get_tree().create_timer(persist_ms).timeout
-		mesh_instance.queue_free()
-	else:
-		return mesh_instance
 
+	return await final_cleanup(mesh_instance, persist_ms)
 
-func point(pos:Vector3, radius = 0.05, color = Color.WHITE_SMOKE, persist_ms = 0):
+func point(pos: Vector3, radius = 0.05, color = Color.WHITE_SMOKE, persist_ms = 0):
 	var mesh_instance := MeshInstance3D.new()
 	var sphere_mesh := SphereMesh.new()
 	var material := ORMMaterial3D.new()
-		
+
 	mesh_instance.mesh = sphere_mesh
 	mesh_instance.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
 	mesh_instance.position = pos
-	
+
 	sphere_mesh.radius = radius
 	sphere_mesh.height = radius*2
 	sphere_mesh.material = material
-	
+
 	material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
 	material.albedo_color = color
-	
+
+	return await final_cleanup(mesh_instance, persist_ms)
+
+func square(pos: Vector3, size: Vector2, color = Color.WHITE_SMOKE, persist_ms = 0):
+	var mesh_instance := MeshInstance3D.new()
+	var box_mesh := BoxMesh.new()
+	var material := ORMMaterial3D.new()
+
+	mesh_instance.mesh = box_mesh
+	mesh_instance.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+	mesh_instance.position = pos
+
+	box_mesh.size = Vector3(size.x, size.y, 1)
+	box_mesh.material = material
+
+	material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+	material.albedo_color = color
+
+	return await final_cleanup(mesh_instance, persist_ms)
+
+## 1 -> Lasts ONLY for current physics frame
+## >1 -> Lasts X time duration.
+## <1 -> Stays indefinitely
+func final_cleanup(mesh_instance: MeshInstance3D, persist_ms: float):
 	get_tree().get_root().add_child(mesh_instance)
-	if persist_ms:
+	if persist_ms == 1:
+		await get_tree().physics_frame
+		mesh_instance.queue_free()
+	elif persist_ms > 0:
 		await get_tree().create_timer(persist_ms).timeout
 		mesh_instance.queue_free()
 	else:
 		return mesh_instance
-


### PR DESCRIPTION
In the previous code, I was unable to render a point or line for this frame, or a tiny amount like 0.005 - Godot's timers have a minimum duration. With this, the shape can be rendered only for physics frame. The result is that this script can now be used for physics visualizations, and ofc debugging.

I also wanted a cube shape for my physics debugging, so I added that.
Also added a cleanup function since it's the same for all 3 shapes.